### PR TITLE
add close function option and centering widgets square and cam

### DIFF
--- a/lib/src/qrcode_reader_view.dart
+++ b/lib/src/qrcode_reader_view.dart
@@ -37,7 +37,7 @@ class QrcodeReaderView extends StatefulWidget {
     this.screenCamSize,
     this.positionCam,
     this.closePositionButton,
-    this.bottomContent, 
+    this.bottomContent,
     this.onClose,
   }) : super(key: key);
 
@@ -177,13 +177,12 @@ class QrcodeReaderViewState extends State<QrcodeReaderView> {
                   );
                 }
                 return Stack(
+                  alignment: Alignment.center,
                   children: <Widget>[
                     //ImagePreview
                     Positioned(
-                      left: widget.positionCam?.width ??
-                          (constraints.maxWidth - qrScanSize) / 2,
-                      top: widget.positionCam?.height ??
-                          (constraints.maxHeight - qrScanSize) / 2,
+                      left: widget.positionCam?.width,
+                      top: widget.positionCam?.height,
                       child: SizedBox(
                         width: widget.screenCamSize?.width ??
                             constraints.maxWidth * 0.84,
@@ -201,8 +200,8 @@ class QrcodeReaderViewState extends State<QrcodeReaderView> {
                     //
                     widget.scanWidget ??
                         Positioned(
-                          left: (constraints.maxWidth - qrScanSize) / 2,
-                          top: (constraints.maxHeight - qrScanSize) / 2,
+                          // left: (constraints.maxWidth - qrScanSize) / 2,
+                          // top: (constraints.maxHeight - qrScanSize) / 2,
                           child: CustomPaint(
                             painter: QrScanBoxPainter(
                               boxLineColor: widget.boxLineColor ?? Colors.red,
@@ -232,7 +231,8 @@ class QrcodeReaderViewState extends State<QrcodeReaderView> {
                       left: widget.closePositionButton?.width ??
                           MediaQuery.of(context).size.width * .085,
                       child: InkWell(
-                        onTap:  widget.onClose ?? () => Navigator.of(context).pop(),
+                        onTap:
+                            widget.onClose ?? () => Navigator.of(context).pop(),
                         child: Icon(
                           Icons.close,
                           color: const Color(0xff969696),

--- a/lib/src/qrcode_reader_view.dart
+++ b/lib/src/qrcode_reader_view.dart
@@ -12,6 +12,7 @@ import 'qrcode_reader_controller.dart';
 /// Relevant privileges must be obtained before use
 class QrcodeReaderView extends StatefulWidget {
   final Future Function(String) onScan;
+  final Future Function()? onClose;
   final ReaderFrom readerFrom;
   final Widget? headerWidget;
   final double? scanBoxRatio;
@@ -36,7 +37,8 @@ class QrcodeReaderView extends StatefulWidget {
     this.screenCamSize,
     this.positionCam,
     this.closePositionButton,
-    this.bottomContent,
+    this.bottomContent, 
+    this.onClose,
   }) : super(key: key);
 
   @override
@@ -230,7 +232,7 @@ class QrcodeReaderViewState extends State<QrcodeReaderView> {
                       left: widget.closePositionButton?.width ??
                           MediaQuery.of(context).size.width * .085,
                       child: InkWell(
-                        onTap: () => Navigator.of(context).pop(),
+                        onTap:  widget.onClose ?? () => Navigator.of(context).pop(),
                         child: Icon(
                           Icons.close,
                           color: const Color(0xff969696),

--- a/lib/src/scan_view.dart
+++ b/lib/src/scan_view.dart
@@ -9,6 +9,7 @@ class ScanView extends StatefulWidget {
   final Widget? scanWidget;
   final Size? screenCamSize;
   final Size? positionCam;
+  final Future Function()? onClose;
   final Function(String)? afterScan;
   final Widget? bottomContent;
   final ReaderFrom readerFrom;
@@ -21,7 +22,8 @@ class ScanView extends StatefulWidget {
     this.positionCam,
     this.afterScan,
     this.bottomContent,
-    required this.readerFrom,
+    required this.readerFrom, 
+    this.onClose,
   }) : super(key: key);
 
   @override
@@ -36,6 +38,7 @@ class _ScanViewState extends State<ScanView> {
     return Scaffold(
       body: QrcodeReaderView(
         readerFrom: widget.readerFrom,
+        onClose: widget.onClose,
         key: _key,
         onScan: onScan,
         // headerWidget: AppBar(


### PR DESCRIPTION
Hello, i add a option to add function at close button instead navigator.pop only, to i add center aligment to stack on ScanView to centering Cam and Square.

before
![image](https://user-images.githubusercontent.com/37966182/142861438-110a0d39-5ed0-4438-af77-fa9f9c6cdfb2.png)

after
![image](https://user-images.githubusercontent.com/37966182/142861298-1ddef335-3d98-47ec-8bcc-924c4d9760d3.png)
